### PR TITLE
feat: add replace token lock reference support for token lock operations

### DIFF
--- a/packages/dag4-network/src/dto/v2/swap-operations.ts
+++ b/packages/dag4-network/src/dto/v2/swap-operations.ts
@@ -28,6 +28,7 @@ export type TokenLock = {
   amount: number;
   fee?: number;
   unlockEpoch: number | null;
+  replaceTokenLockRef: string | null;
 };
 
 export type TokenLockWithCurrencyId = WithCurrencyId<TokenLock>;

--- a/packages/dag4-wallet/src/dag-account.ts
+++ b/packages/dag4-wallet/src/dag-account.ts
@@ -659,6 +659,7 @@ export class DagAccount {
     unlockEpoch: number | null;
     currencyId: string | null;
     fee?: number;
+    replaceTokenLockRef: string | null;
   }) {
     console.warn(
       "postTokenLock() is deprecated. Use createTokenLock() instead."
@@ -668,7 +669,7 @@ export class DagAccount {
 
     validateSchema(body, postTokenLockSchema, true);
 
-    const { amount, currencyId, fee, source, tokenL1Url, unlockEpoch } = body;
+    const { amount, currencyId, fee, source, tokenL1Url, unlockEpoch, replaceTokenLockRef } = body;
 
     if (source !== this.address) {
       throw new Error('"source" must be the same as the account address');
@@ -702,7 +703,9 @@ export class DagAccount {
         currencyId: currencyId ?? null,
         fee: fee ?? 0,
         unlockEpoch: unlockEpoch ?? null,
+        replaceTokenLockRef: replaceTokenLockRef ?? null,
       };
+  
       signedTokenLock = await keyStore.generateBrotliSignature(
         tokenLockBody,
         normalizePublicKey(this.publicKey),

--- a/packages/dag4-wallet/src/shared/operations.ts
+++ b/packages/dag4-wallet/src/shared/operations.ts
@@ -131,6 +131,7 @@ export const tokenLock = async (
       currencyId: body.currencyId ?? null,
       fee: body.fee ?? 0,
       unlockEpoch: body.unlockEpoch ?? null,
+      replaceTokenLockRef: body.replaceTokenLockRef ?? null,
     };
     signedTokenLock = await keyStore.generateBrotliSignature(
       tokenLockBody,

--- a/packages/dag4-wallet/src/validationSchemas.ts
+++ b/packages/dag4-wallet/src/validationSchemas.ts
@@ -73,6 +73,11 @@ export const tokenLockSchema = z.object({
     .refine((value) => value === null || value > 0, {
       message: "Unlock epoch must be greater than zero or null",
     }),
+  replaceTokenLockRef: z
+    .union([z.string(), z.null()])
+    .refine((value) => value === null || value !== "", {
+      message: "Must be a valid hash or null",
+    }),
 });
 
 /**


### PR DESCRIPTION
This PR is a sister PR of https://github.com/Constellation-Labs/tessellation/pull/1294. It introduces the `replaceTokenLockRef` field to the `TokenLock` object, which is used to increase the token lock amount.