### PR TITLE
feature [SGW-904] add params on post requests in L1 api

### DIFF
--- a/packages/dag4-network/src/api/v2/l1-api.ts
+++ b/packages/dag4-network/src/api/v2/l1-api.ts
@@ -1,4 +1,4 @@
-import { RestApi, RestApiOptions } from "@stardust-collective/dag4-core";
+import { RestApi } from "@stardust-collective/dag4-core";
 import { DNC } from "../../DNC";
 import {
   ClusterInfoV2,
@@ -90,8 +90,8 @@ class L1Api {
     );
   }
 
-  async postAllowSpend(signedAllowSpend: SignedAllowSpend, params?: Record<string, any>, options?: RestApiOptions) {
-    return this.service.$post<HashResponse>(`/allow-spends`, signedAllowSpend, options, params);
+  async postAllowSpend(signedAllowSpend: SignedAllowSpend, params?: Record<string, any>) {
+    return this.service.$post<HashResponse>(`/allow-spends`, signedAllowSpend, {}, params);
   }
 
   async getTokenLockLastRef(address: string) {
@@ -100,16 +100,16 @@ class L1Api {
     );
   }
 
-  async postTokenLock(signedTokenLock: SignedTokenLock, params?: Record<string, any>, options?: RestApiOptions) {
-    return this.service.$post<HashResponse>(`/token-locks`, signedTokenLock, options, params);
+  async postTokenLock(signedTokenLock: SignedTokenLock, params?: Record<string, any>) {
+    return this.service.$post<HashResponse>(`/token-locks`, signedTokenLock, {}, params);
   }
 
   async getPendingTransaction(hash: string) {
     return this.service.$get<PendingTransaction>(`/transactions/${hash}`);
   }
 
-  async postTransaction(tx: PostTransactionV2, params?: Record<string, any>, options?: RestApiOptions) {
-    return this.service.$post<PostTransactionResponseV2>("/transactions", tx, options, params);
+  async postTransaction(tx: PostTransactionV2, params?: Record<string, any>) {
+    return this.service.$post<PostTransactionResponseV2>("/transactions", tx, {}, params);
   }
 
   async getClusterInfo(): Promise<ClusterPeerInfoV2[]> {

--- a/packages/dag4-network/src/api/v2/l1-api.ts
+++ b/packages/dag4-network/src/api/v2/l1-api.ts
@@ -1,4 +1,4 @@
-import { RestApi } from "@stardust-collective/dag4-core";
+import { RestApi, RestApiOptions } from "@stardust-collective/dag4-core";
 import { DNC } from "../../DNC";
 import {
   ClusterInfoV2,
@@ -90,8 +90,8 @@ class L1Api {
     );
   }
 
-  async postAllowSpend(signedAllowSpend: SignedAllowSpend) {
-    return this.service.$post<HashResponse>(`/allow-spends`, signedAllowSpend);
+  async postAllowSpend(signedAllowSpend: SignedAllowSpend, params?: Record<string, any>, options?: RestApiOptions) {
+    return this.service.$post<HashResponse>(`/allow-spends`, signedAllowSpend, options, params);
   }
 
   async getTokenLockLastRef(address: string) {
@@ -100,16 +100,16 @@ class L1Api {
     );
   }
 
-  async postTokenLock(signedTokenLock: SignedTokenLock) {
-    return this.service.$post<HashResponse>(`/token-locks`, signedTokenLock);
+  async postTokenLock(signedTokenLock: SignedTokenLock, params?: Record<string, any>, options?: RestApiOptions) {
+    return this.service.$post<HashResponse>(`/token-locks`, signedTokenLock, options, params);
   }
 
   async getPendingTransaction(hash: string) {
     return this.service.$get<PendingTransaction>(`/transactions/${hash}`);
   }
 
-  async postTransaction(tx: PostTransactionV2) {
-    return this.service.$post<PostTransactionResponseV2>("/transactions", tx);
+  async postTransaction(tx: PostTransactionV2, params?: Record<string, any>, options?: RestApiOptions) {
+    return this.service.$post<PostTransactionResponseV2>("/transactions", tx, options, params);
   }
 
   async getClusterInfo(): Promise<ClusterPeerInfoV2[]> {

--- a/packages/dag4-network/src/dag-network.ts
+++ b/packages/dag4-network/src/dag-network.ts
@@ -7,6 +7,7 @@ import { L1Api } from './api/v2/l1-api';
 import { CbTransaction, PostTransaction, Snapshot, Transaction } from './dto/v1';
 import { PendingTransaction, PostTransactionV2, SnapshotV2, TransactionV2 } from './dto/v2';
 import { NetworkInfo } from './types/network-info';
+import { RestApiOptions } from '@stardust-collective/dag4-core';
 
 export class DagNetwork {
   private connectedNetwork: NetworkInfo = { 
@@ -124,9 +125,9 @@ export class DagNetwork {
     return this.blockExplorerApi.getTransaction(hash);
   }
 
-  async postTransaction(tx: PostTransaction | PostTransactionV2): Promise<string> {
+  async postTransaction(tx: PostTransaction | PostTransactionV2, params?: Record<string, any>, options?: RestApiOptions): Promise<string> {
     if (this.getNetworkVersion() === '2.0') {
-      const response = await this.l1Api.postTransaction(tx as PostTransactionV2) as any;
+      const response = await this.l1Api.postTransaction(tx as PostTransactionV2, params, options) as any;
 
       // Support data/meta format and object return format
       return response.data ? response.data.hash : response.hash;

--- a/packages/dag4-network/src/dag-network.ts
+++ b/packages/dag4-network/src/dag-network.ts
@@ -7,7 +7,6 @@ import { L1Api } from './api/v2/l1-api';
 import { CbTransaction, PostTransaction, Snapshot, Transaction } from './dto/v1';
 import { PendingTransaction, PostTransactionV2, SnapshotV2, TransactionV2 } from './dto/v2';
 import { NetworkInfo } from './types/network-info';
-import { RestApiOptions } from '@stardust-collective/dag4-core';
 
 export class DagNetwork {
   private connectedNetwork: NetworkInfo = { 
@@ -125,9 +124,9 @@ export class DagNetwork {
     return this.blockExplorerApi.getTransaction(hash);
   }
 
-  async postTransaction(tx: PostTransaction | PostTransactionV2, params?: Record<string, any>, options?: RestApiOptions): Promise<string> {
+  async postTransaction(tx: PostTransaction | PostTransactionV2, params?: Record<string, any>): Promise<string> {
     if (this.getNetworkVersion() === '2.0') {
-      const response = await this.l1Api.postTransaction(tx as PostTransactionV2, params, options) as any;
+      const response = await this.l1Api.postTransaction(tx as PostTransactionV2, params) as any;
 
       // Support data/meta format and object return format
       return response.data ? response.data.hash : response.hash;

--- a/packages/dag4-network/src/metagraph-token-network.ts
+++ b/packages/dag4-network/src/metagraph-token-network.ts
@@ -1,4 +1,3 @@
-import { RestApiOptions } from "@stardust-collective/dag4-core";
 import { MetagraphTokenDataL1Api } from "./api/metagraph-token/data-l1-api";
 import { MetagraphTokenL0Api } from "./api/metagraph-token/l0-api";
 import { MetagraphTokenL1Api } from "./api/metagraph-token/l1-api";
@@ -151,11 +150,10 @@ class MetagraphTokenNetwork {
     return response ? response.data : null;
   }
 
-  async postTransaction(tx: PostTransactionV2, params?: Record<string, any>, options?: RestApiOptions): Promise<string> {
+  async postTransaction(tx: PostTransactionV2, params?: Record<string, any>): Promise<string> {
     const response = (await this.l1Api.postTransaction(
       tx as PostTransactionV2,
-      params,
-      options
+      params
     )) as any;
 
     // Support data/meta format and object return format

--- a/packages/dag4-network/src/metagraph-token-network.ts
+++ b/packages/dag4-network/src/metagraph-token-network.ts
@@ -1,3 +1,4 @@
+import { RestApiOptions } from "@stardust-collective/dag4-core";
 import { MetagraphTokenDataL1Api } from "./api/metagraph-token/data-l1-api";
 import { MetagraphTokenL0Api } from "./api/metagraph-token/l0-api";
 import { MetagraphTokenL1Api } from "./api/metagraph-token/l1-api";
@@ -150,9 +151,11 @@ class MetagraphTokenNetwork {
     return response ? response.data : null;
   }
 
-  async postTransaction(tx: PostTransactionV2): Promise<string> {
+  async postTransaction(tx: PostTransactionV2, params?: Record<string, any>, options?: RestApiOptions): Promise<string> {
     const response = (await this.l1Api.postTransaction(
-      tx as PostTransactionV2
+      tx as PostTransactionV2,
+      params,
+      options
     )) as any;
 
     // Support data/meta format and object return format

--- a/packages/dag4-wallet/src/dag-account.ts
+++ b/packages/dag4-wallet/src/dag-account.ts
@@ -1,4 +1,4 @@
-import { DAG_DECIMALS, RestApiOptions } from "@stardust-collective/dag4-core";
+import { DAG_DECIMALS } from "@stardust-collective/dag4-core";
 import {
   keyStore,
   KeyTrio,
@@ -359,8 +359,7 @@ export class DagAccount {
     amount: number,
     fee = 0,
     autoEstimateFee = false,
-    params?: Record<string, any>,
-    options?: RestApiOptions
+    params?: Record<string, any>
   ): Promise<PendingTx> {
     let normalizedAmount = Math.floor(
       new BigNumber(amount).multipliedBy(DAG_DECIMALS).toNumber()
@@ -387,7 +386,7 @@ export class DagAccount {
     }
 
     const tx = await this.generateSignedTransaction(toAddress, amount, fee);
-    const txHash = await this.network.postTransaction(tx, params, options);
+    const txHash = await this.network.postTransaction(tx, params);
 
     if (txHash) {
       return {
@@ -635,7 +634,7 @@ export class DagAccount {
     return allowSpendResponse;
   }
 
-  async createAllowSpend(body: AllowSpend, params?: Record<string, any>, options?: RestApiOptions) {
+  async createAllowSpend(body: AllowSpend, params?: Record<string, any>) {
     this.assertAccountIsActive();
     this.assertValidPrivateKey();
 
@@ -648,7 +647,7 @@ export class DagAccount {
       currencyId: null,
     };
 
-    return allowSpend(bodyWithCurrencyId, this.network, this.keyTrio, params, options);
+    return allowSpend(bodyWithCurrencyId, this.network, this.keyTrio, params);
   }
 
   /**
@@ -737,7 +736,7 @@ export class DagAccount {
     return tokenLockResponse;
   }
 
-  async createTokenLock(body: TokenLock, params?: Record<string, any>, options?: RestApiOptions) {
+  async createTokenLock(body: TokenLock, params?: Record<string, any>) {
     this.assertAccountIsActive();
     this.assertValidPrivateKey();
 
@@ -750,7 +749,7 @@ export class DagAccount {
       currencyId: null,
     };
 
-    return tokenLock(bodyWithCurrencyId, this.network, this.keyTrio, params, options);
+    return tokenLock(bodyWithCurrencyId, this.network, this.keyTrio, params);
   }
 
   /**

--- a/packages/dag4-wallet/src/dag-account.ts
+++ b/packages/dag4-wallet/src/dag-account.ts
@@ -1,4 +1,4 @@
-import { DAG_DECIMALS } from "@stardust-collective/dag4-core";
+import { DAG_DECIMALS, RestApiOptions } from "@stardust-collective/dag4-core";
 import {
   keyStore,
   KeyTrio,
@@ -633,7 +633,7 @@ export class DagAccount {
     return allowSpendResponse;
   }
 
-  async createAllowSpend(body: AllowSpend) {
+  async createAllowSpend(body: AllowSpend, params?: Record<string, any>, options?: RestApiOptions) {
     this.assertAccountIsActive();
     this.assertValidPrivateKey();
 
@@ -646,7 +646,7 @@ export class DagAccount {
       currencyId: null,
     };
 
-    return allowSpend(bodyWithCurrencyId, this.network, this.keyTrio);
+    return allowSpend(bodyWithCurrencyId, this.network, this.keyTrio, params, options);
   }
 
   /**
@@ -735,7 +735,7 @@ export class DagAccount {
     return tokenLockResponse;
   }
 
-  async createTokenLock(body: TokenLock) {
+  async createTokenLock(body: TokenLock, params?: Record<string, any>, options?: RestApiOptions) {
     this.assertAccountIsActive();
     this.assertValidPrivateKey();
 
@@ -748,7 +748,7 @@ export class DagAccount {
       currencyId: null,
     };
 
-    return tokenLock(bodyWithCurrencyId, this.network, this.keyTrio);
+    return tokenLock(bodyWithCurrencyId, this.network, this.keyTrio, params, options);
   }
 
   /**

--- a/packages/dag4-wallet/src/dag-account.ts
+++ b/packages/dag4-wallet/src/dag-account.ts
@@ -358,7 +358,9 @@ export class DagAccount {
     toAddress: string,
     amount: number,
     fee = 0,
-    autoEstimateFee = false
+    autoEstimateFee = false,
+    params?: Record<string, any>,
+    options?: RestApiOptions
   ): Promise<PendingTx> {
     let normalizedAmount = Math.floor(
       new BigNumber(amount).multipliedBy(DAG_DECIMALS).toNumber()
@@ -385,7 +387,7 @@ export class DagAccount {
     }
 
     const tx = await this.generateSignedTransaction(toAddress, amount, fee);
-    const txHash = await this.network.postTransaction(tx);
+    const txHash = await this.network.postTransaction(tx, params, options);
 
     if (txHash) {
       return {

--- a/packages/dag4-wallet/src/metagraph-token-client.ts
+++ b/packages/dag4-wallet/src/metagraph-token-client.ts
@@ -1,4 +1,4 @@
-import { DAG_DECIMALS } from "@stardust-collective/dag4-core";
+import { DAG_DECIMALS, RestApiOptions } from "@stardust-collective/dag4-core";
 import { PostTransactionV2 } from "@stardust-collective/dag4-keystore";
 import {
   ActionType,
@@ -249,7 +249,7 @@ class MetagraphTokenClient {
     return this.sendBatchTransactions(txns);
   }
 
-  async createAllowSpend(body: AllowSpend) {
+  async createAllowSpend(body: AllowSpend, params?: Record<string, any>, options?: RestApiOptions) {
     this.account.assertAccountIsActive();
     this.account.assertValidPrivateKey();
 
@@ -262,10 +262,10 @@ class MetagraphTokenClient {
       currencyId: this.networkInfo.metagraphId,
     };
 
-    return allowSpend(bodyWithCurrencyId, this.network, this.account.keyTrio);
+    return allowSpend(bodyWithCurrencyId, this.network, this.account.keyTrio, params, options);
   }
 
-  async createTokenLock(body: TokenLock) {
+  async createTokenLock(body: TokenLock, params?: Record<string, any>, options?: RestApiOptions) {
     this.account.assertAccountIsActive();
     this.account.assertValidPrivateKey();
 
@@ -278,7 +278,7 @@ class MetagraphTokenClient {
       currencyId: this.networkInfo.metagraphId,
     };
 
-    return tokenLock(bodyWithCurrencyId, this.network, this.account.keyTrio);
+    return tokenLock(bodyWithCurrencyId, this.network, this.account.keyTrio, params, options);
   }
 
   async getDataFeeEstimate(data: any) {

--- a/packages/dag4-wallet/src/metagraph-token-client.ts
+++ b/packages/dag4-wallet/src/metagraph-token-client.ts
@@ -1,4 +1,4 @@
-import { DAG_DECIMALS, RestApiOptions } from "@stardust-collective/dag4-core";
+import { DAG_DECIMALS } from "@stardust-collective/dag4-core";
 import { PostTransactionV2 } from "@stardust-collective/dag4-keystore";
 import {
   ActionType,
@@ -116,8 +116,7 @@ class MetagraphTokenClient {
     amount: number,
     fee = 0,
     autoEstimateFee = false,
-    params?: Record<string, any>,
-    options?: RestApiOptions
+    params?: Record<string, any>
   ): Promise<PendingTx> {
     let normalizedAmount = Math.floor(
       new BigNumber(amount).multipliedBy(this.tokenDecimals).toNumber()
@@ -154,7 +153,7 @@ class MetagraphTokenClient {
       throw new Error("Unable to post v1 transaction");
     }
 
-    const txHash = await this.network.postTransaction(tx, params, options);
+    const txHash = await this.network.postTransaction(tx, params);
 
     if (txHash) {
       return {
@@ -251,7 +250,7 @@ class MetagraphTokenClient {
     return this.sendBatchTransactions(txns);
   }
 
-  async createAllowSpend(body: AllowSpend, params?: Record<string, any>, options?: RestApiOptions) {
+  async createAllowSpend(body: AllowSpend, params?: Record<string, any>) {
     this.account.assertAccountIsActive();
     this.account.assertValidPrivateKey();
 
@@ -264,10 +263,10 @@ class MetagraphTokenClient {
       currencyId: this.networkInfo.metagraphId,
     };
 
-    return allowSpend(bodyWithCurrencyId, this.network, this.account.keyTrio, params, options);
+    return allowSpend(bodyWithCurrencyId, this.network, this.account.keyTrio, params);
   }
 
-  async createTokenLock(body: TokenLock, params?: Record<string, any>, options?: RestApiOptions) {
+  async createTokenLock(body: TokenLock, params?: Record<string, any>) {
     this.account.assertAccountIsActive();
     this.account.assertValidPrivateKey();
 
@@ -280,7 +279,7 @@ class MetagraphTokenClient {
       currencyId: this.networkInfo.metagraphId,
     };
 
-    return tokenLock(bodyWithCurrencyId, this.network, this.account.keyTrio, params, options);
+    return tokenLock(bodyWithCurrencyId, this.network, this.account.keyTrio, params);
   }
 
   async getDataFeeEstimate(data: any) {

--- a/packages/dag4-wallet/src/metagraph-token-client.ts
+++ b/packages/dag4-wallet/src/metagraph-token-client.ts
@@ -115,7 +115,9 @@ class MetagraphTokenClient {
     toAddress: string,
     amount: number,
     fee = 0,
-    autoEstimateFee = false
+    autoEstimateFee = false,
+    params?: Record<string, any>,
+    options?: RestApiOptions
   ): Promise<PendingTx> {
     let normalizedAmount = Math.floor(
       new BigNumber(amount).multipliedBy(this.tokenDecimals).toNumber()
@@ -152,7 +154,7 @@ class MetagraphTokenClient {
       throw new Error("Unable to post v1 transaction");
     }
 
-    const txHash = await this.network.postTransaction(tx);
+    const txHash = await this.network.postTransaction(tx, params, options);
 
     if (txHash) {
       return {

--- a/packages/dag4-wallet/src/shared/operations.ts
+++ b/packages/dag4-wallet/src/shared/operations.ts
@@ -19,13 +19,16 @@ import {
   validateArraySchema,
   validateSchema,
 } from "../validationSchemas";
+import { RestApiOptions } from "@stardust-collective/dag4-core";
 
 type SharedNetwork = DagNetwork | GlobalDagNetwork | MetagraphTokenNetwork;
 
 export const allowSpend = async (
   body: AllowSpendWithCurrencyId,
   network: SharedNetwork,
-  keyTrio: KeyTrio
+  keyTrio: KeyTrio,
+  params?: Record<string, any>,
+  options?: RestApiOptions
 ): Promise<HashResponse> => {
   validateSchema(body, allowSpendSchema, true);
 
@@ -82,7 +85,7 @@ export const allowSpend = async (
 
   try {
     // Post signed allow spend body
-    allowSpendResponse = await network.l1Api.postAllowSpend(signedAllowSpend);
+    allowSpendResponse = await network.l1Api.postAllowSpend(signedAllowSpend, params, options);
   } catch (err) {
     console.error("Error sending the allow spend transaction");
     throw err;
@@ -98,7 +101,9 @@ export const allowSpend = async (
 export const tokenLock = async (
   body: TokenLockWithCurrencyId,
   network: SharedNetwork,
-  keyTrio: KeyTrio
+  keyTrio: KeyTrio,
+  params?: Record<string, any>,
+  options?: RestApiOptions
 ): Promise<HashResponse> => {
   validateSchema(body, tokenLockSchema, true);
 
@@ -148,7 +153,7 @@ export const tokenLock = async (
 
   try {
     // Post signed token lock body
-    tokenLockResponse = await network.l1Api.postTokenLock(signedTokenLock);
+    tokenLockResponse = await network.l1Api.postTokenLock(signedTokenLock, params, options);
   } catch (err) {
     console.error("Error sending the token lock transaction");
     throw err;

--- a/packages/dag4-wallet/src/shared/operations.ts
+++ b/packages/dag4-wallet/src/shared/operations.ts
@@ -19,7 +19,6 @@ import {
   validateArraySchema,
   validateSchema,
 } from "../validationSchemas";
-import { RestApiOptions } from "@stardust-collective/dag4-core";
 
 type SharedNetwork = DagNetwork | GlobalDagNetwork | MetagraphTokenNetwork;
 
@@ -27,8 +26,7 @@ export const allowSpend = async (
   body: AllowSpendWithCurrencyId,
   network: SharedNetwork,
   keyTrio: KeyTrio,
-  params?: Record<string, any>,
-  options?: RestApiOptions
+  params?: Record<string, any>
 ): Promise<HashResponse> => {
   validateSchema(body, allowSpendSchema, true);
 
@@ -85,7 +83,7 @@ export const allowSpend = async (
 
   try {
     // Post signed allow spend body
-    allowSpendResponse = await network.l1Api.postAllowSpend(signedAllowSpend, params, options);
+    allowSpendResponse = await network.l1Api.postAllowSpend(signedAllowSpend, params);
   } catch (err) {
     console.error("Error sending the allow spend transaction");
     throw err;
@@ -102,8 +100,7 @@ export const tokenLock = async (
   body: TokenLockWithCurrencyId,
   network: SharedNetwork,
   keyTrio: KeyTrio,
-  params?: Record<string, any>,
-  options?: RestApiOptions
+  params?: Record<string, any>
 ): Promise<HashResponse> => {
   validateSchema(body, tokenLockSchema, true);
 
@@ -153,7 +150,7 @@ export const tokenLock = async (
 
   try {
     // Post signed token lock body
-    tokenLockResponse = await network.l1Api.postTokenLock(signedTokenLock, params, options);
+    tokenLockResponse = await network.l1Api.postTokenLock(signedTokenLock, params);
   } catch (err) {
     console.error("Error sending the token lock transaction");
     throw err;


### PR DESCRIPTION
[SGW-904](https://constellationnetwork.atlassian.net/browse/SGW-904)

## Changes
- Added `params` and `options` as optional fields in the following methods:
  - postAllowSpend()
  - postTokenLock()
  - postTransaction()
 - Expose new params on clients: `dag-account` and `metagraph-token-client`
 

[SGW-904]: https://constellationnetwork.atlassian.net/browse/SGW-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ